### PR TITLE
Fixes for issues #1 and #3

### DIFF
--- a/scripts/docker_build_ml.sh
+++ b/scripts/docker_build_ml.sh
@@ -111,6 +111,16 @@ if [[ "$CONTAINERS" == "all" ]]; then
 			--build-arg BASE_IMAGE=$BASE_IMAGE \
 			--build-arg PYTORCH_IMAGE=l4t-pytorch:r$L4T_VERSION-pth1.6-py3 \
 			--build-arg TENSORFLOW_IMAGE=l4t-tensorflow:r$L4T_VERSION-tf1.15-py3
+
+	sh ./scripts/docker_build.sh l4t-ml:r$L4T_VERSION-tf1.15-py3 Dockerfile.ml \
+			--build-arg BASE_IMAGE=$BASE_IMAGE \
+			--build-arg PYTORCH_IMAGE=l4t-pytorch:r$L4T_VERSION-pth1.6-py3 \
+			--build-arg TENSORFLOW_IMAGE=l4t-tensorflow:r$L4T_VERSION-tf1.15-py3
+
+	sh ./scripts/docker_build.sh l4t-ml:r$L4T_VERSION-tf2.3-py3 Dockerfile.ml \
+			--build-arg BASE_IMAGE=$BASE_IMAGE \
+			--build-arg PYTORCH_IMAGE=l4t-pytorch:r$L4T_VERSION-pth1.6-py3 \
+			--build-arg TENSORFLOW_IMAGE=l4t-tensorflow:r$L4T_VERSION-tf2.3-py3
 fi
 
 

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,8 +1,34 @@
 #!/usr/bin/env bash
 
+set -e
+
+# check what to push
+if [ "$1" == "" ]
+then
+  echo "You need to specify two arguments: the first argument is what"
+  echo "to push and the second argument is the destination image"
+  echo "registry where you are authenticated for pushing."
+  echo ""
+  echo "Valid values for what to push are 'pytorch', 'tensorflow'"
+  echo "'ml', or 'all'."
+  exit -1
+fi
+
+# check the destination
+if [ "$2" == "" ]
+then
+  echo "You need to specify two arguments: the first argument is what"
+  echo "to push and the second argument is the destination image"
+  echo "registry where you are authenticated for pushing."
+  echo ""
+  echo "Valid values for what to push are 'pytorch', 'tensorflow'"
+  echo "'ml', or 'all'."
+  exit -2
+fi
+
 source scripts/l4t_version.sh
 
-REPOSITORY=${2:-"docker.io/edgyr"}
+REGISTRY=${2:-"docker.io/edgyr"}
 CONTAINERS=${1:-"all"}
 
 push_retag() 
@@ -10,12 +36,12 @@ push_retag()
 	local src_tag=$1
 	local dst_tag=$2
 	
-	sudo docker rmi $REPOSITORY/$dst_tag
-	sudo docker tag $src_tag $REPOSITORY/$dst_tag
+	sudo docker rmi $REGISTRY/$dst_tag
+	sudo docker tag $src_tag $REGISTRY/$dst_tag
 	
-	echo "pushing container $src_tag => $REPOSITORY/$dst_tag"
-	sudo docker push $REPOSITORY/$dst_tag
-	echo "done pushing $REPOSITORY/$dst_tag"
+	echo "pushing container $src_tag => $REGISTRY/$dst_tag"
+	sudo docker push $REGISTRY/$dst_tag
+	echo "done pushing $REGISTRY/$dst_tag"
 }
 
 push() 

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -2,7 +2,7 @@
 
 source scripts/l4t_version.sh
 
-NGC_GROUP="nvcr.io/ea-linux4tegra"
+REPOSITORY=${2:-"docker.io/edgyr"}
 CONTAINERS=${1:-"all"}
 
 push_retag() 
@@ -10,12 +10,12 @@ push_retag()
 	local src_tag=$1
 	local dst_tag=$2
 	
-	sudo docker rmi $NGC_GROUP/$dst_tag
-	sudo docker tag $src_tag $NGC_GROUP/$dst_tag
+	sudo docker rmi $REPOSITORY/$dst_tag
+	sudo docker tag $src_tag $REPOSITORY/$dst_tag
 	
-	echo "pushing container $src_tag => $NGC_GROUP/$dst_tag"
-	sudo docker push $NGC_GROUP/$dst_tag
-	echo "done pushing $NGC_GROUP/$dst_tag"
+	echo "pushing container $src_tag => $REPOSITORY/$dst_tag"
+	sudo docker push $REPOSITORY/$dst_tag
+	echo "done pushing $REPOSITORY/$dst_tag"
 }
 
 push() 
@@ -38,4 +38,6 @@ fi
 
 if [[ "$CONTAINERS" == "ml" || "$CONTAINERS" == "all" ]]; then
 	push "l4t-ml:r$L4T_VERSION-py3"
+	push "l4t-ml:r$L4T_VERSION-tf1.15-py3"
+	push "l4t-ml:r$L4T_VERSION-tf2.3-py3"
 fi

--- a/scripts/docker_test_ml.sh
+++ b/scripts/docker_test_ml.sh
@@ -158,6 +158,8 @@ fi
 #
 if [[ "$CONTAINERS" == "ml" || "$CONTAINERS" == "all" ]]; then
 	test_all "l4t-ml:r$L4T_VERSION-py3"
+	test_all "l4t-ml:r$L4T_VERSION-tf1.15-py3"
+	test_all "l4t-ml:r$L4T_VERSION-tf2.3-py3"
 fi
 
 


### PR DESCRIPTION
1. Push script requires specifying a destination image registry where the user has push access.
2. Three `ml` images are created: the original, with TensorFlow 1.15, a copy of the original tagged with `tf1.15`, and a new image using TensorFlow 2.3 and tagged with `tf2.3`.